### PR TITLE
remove duplicate `allocPlane` method

### DIFF
--- a/yuv-buffer.js
+++ b/yuv-buffer.js
@@ -134,21 +134,6 @@ var YUVBuffer = {
   },
 
   /**
-   * Allocate a new YUVPlane object of the given size.
-   * @param {number} stride - byte distance between rows
-   * @param {number} rows - number of rows to allocate
-   * @returns {YUVPlane} - freshly allocated planar buffer
-   */
-  allocPlane: function(stride, rows) {
-    YUVBuffer.validateDimension(stride);
-    YUVBuffer.validateDimension(rows);
-    return {
-      bytes: new Uint8Array(stride * rows),
-      stride: stride
-    }
-  },
-
-  /**
    * Pick a suitable stride for a custom-allocated thingy
    * @param {number} width - width in bytes
    * @returns {number} - new width in bytes at least as large


### PR DESCRIPTION
The `YUVBuffer` object has two `allocPlane` keys.

It's not an issue in JavaScript runtimes, but when it's installed as a dependency in a project, and that project uses esbuild to bundle, esbuild will throw a warning and may cause the whole build to fail: https://esbuild.github.io/try/#dAAwLjIzLjEAAGNvbnN0IGEgPSB7IGE6MSwgYToyIH0